### PR TITLE
Fix FastAPI initialization in ms-python

### DIFF
--- a/ms-python/main.py
+++ b/ms-python/main.py
@@ -31,7 +31,6 @@ def find_free_port() -> int:
 
 app = FastAPI(
     docs_url=None,
-    docs_url=f"{API_ROOT}/",
     openapi_url=f"{API_ROOT}/openapi.json",
     redoc_url=None,
     title="ms-python",


### PR DESCRIPTION
## Summary
- remove duplicate FastAPI `docs_url` argument to allow service startup

## Testing
- python -m compileall ms-python/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d5adca7c388329ac78ff1bbefb44a1