### PR TITLE
Fix swagger root access for gateway routes

### DIFF
--- a/ms-kotlin/src/main/kotlin/br/pucpr/msc/SwaggerRedirectController.kt
+++ b/ms-kotlin/src/main/kotlin/br/pucpr/msc/SwaggerRedirectController.kt
@@ -1,0 +1,16 @@
+package br.pucpr.msc
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@RestController
+class SwaggerRedirectController {
+    @GetMapping("")
+    fun redirectToSwagger(): ResponseEntity<Void> =
+        ResponseEntity.status(HttpStatus.FOUND)
+            .location(URI.create("/ms-kotlin/"))
+            .build()
+}

--- a/ms-python/main.py
+++ b/ms-python/main.py
@@ -41,14 +41,10 @@ app.include_router(orders_router, prefix=API_ROOT)
 
 @app.get("/", include_in_schema=False)
 def root() -> RedirectResponse:
-    return RedirectResponse(url=f"{API_ROOT}/", status_code=302)
+    return RedirectResponse(url=f"{API_ROOT}", status_code=302)
 
 
 @app.get(f"{API_ROOT}", include_in_schema=False)
-def swagger_redirect() -> RedirectResponse:
-    return RedirectResponse(url=f"{API_ROOT}/", status_code=302)
-
-
 @app.get(f"{API_ROOT}/", include_in_schema=False)
 def swagger_ui():
     return get_swagger_ui_html(


### PR DESCRIPTION
## Summary
- serve the FastAPI Swagger UI for both `/ms-python` and `/ms-python/` without forcing an extra redirect
- add a Spring controller that redirects `/ms-kotlin` to the Swagger UI so the gateway root URL loads correctly

## Testing
- pytest ms-python/tests

------
https://chatgpt.com/codex/tasks/task_e_690a84174e088329a3dc9d1ade87c9ae